### PR TITLE
fix(errmsg): handle unnamed types in JSON error messages

### DIFF
--- a/errmsg_gpvalidator_test.go
+++ b/errmsg_gpvalidator_test.go
@@ -3,14 +3,18 @@ package errmsg_test
 import (
 	"encoding/json"
 	"errors"
+	"testing"
+
+	"bytes"
+
 	"github.com/daisy1754/errmsg"
 	errmsg_testing "github.com/daisy1754/errmsg/testing"
 	"github.com/go-playground/validator/v10"
-	"testing"
 )
 
 type request struct {
-	UserID string    `json:"userId" validate:"required"`
+	UserID string   `json:"userId" validate:"required"`
+	Names  []string `json:"names"`
 }
 
 func TestRequiredValidationError(t *testing.T) {
@@ -21,4 +25,20 @@ func TestRequiredValidationError(t *testing.T) {
 	err := validate.Struct(r)
 	errmsg_testing.AssertEquals(t, errmsg.Message(err), `'UserID' is a required field`)
 	errmsg_testing.AssertType(t, errors.Unwrap(errmsg.Wrap(err)), validator.ValidationErrors{})
+}
+
+func TestInvalidNamesTypeError(t *testing.T) {
+	var r request
+	input := `{"userId": "123", "names": "John Doe"}`
+	err := json.NewDecoder(bytes.NewReader([]byte(input))).Decode(&r)
+	errmsg_testing.AssertEquals(t, errmsg.Message(err), `'names' should be []string but received string`)
+	errmsg_testing.AssertType(t, errors.Unwrap(errmsg.Wrap(err)), &json.UnmarshalTypeError{})
+}
+
+func TestInvalidNamesValidationError(t *testing.T) {
+	var r request
+	input := `{"userId": "123", "names": 1}`
+	err := json.NewDecoder(bytes.NewReader([]byte(input))).Decode(&r)
+	errmsg_testing.AssertEquals(t, errmsg.Message(err), `'names' should be []string but received number`)
+	errmsg_testing.AssertType(t, errors.Unwrap(errmsg.Wrap(err)), &json.UnmarshalTypeError{})
 }

--- a/errors/JSONTypeError.go
+++ b/errors/JSONTypeError.go
@@ -13,6 +13,9 @@ type JSONTypeError struct {
 func (e *JSONTypeError) Error() string {
 	typeErr := e.Cause
 	expectedType := typeErr.Type.Name()
+	if expectedType == "" {
+		expectedType = typeErr.Type.String()
+	}
 	actualValue := typeErr.Value
 	if isIntType(expectedType) && actualValue == "string" {
 		// instead of saying 'int64' etc, let's just say 'integer'
@@ -31,7 +34,7 @@ func (e *JSONTypeError) Unwrap() error {
 func isIntType(typeName string) bool {
 	return typeName == "int" || typeName == "unit" ||
 		typeName == "int8" || typeName == "unit8" ||
-		typeName == "int16" || typeName == "unit16"||
-		typeName == "int32" || typeName == "unit32"||
+		typeName == "int16" || typeName == "unit16" ||
+		typeName == "int32" || typeName == "unit32" ||
 		typeName == "int64" || typeName == "unit64"
 }


### PR DESCRIPTION
Previously, Type.Name() returned empty strings for unnamed types like slices ([]string), maps, and channels, resulting in unclear error messages like "field should be  but received string".

<img width="621" height="77" alt="image" src="https://github.com/user-attachments/assets/383ba171-8ef4-420b-8c7f-9c7ba0bb261d" />


Now falls back to Type.String() when Name() returns empty, providing clear error messages like "field should be []string but received string".

Fixes JSON unmarshaling error clarity for slice and other unnamed types.

### Root Cause
In Go's reflection system:
- `Type.Name()` returns the type name for **defined types** only
- For **unnamed types** like `[]string`, `map[string]int`, etc., it returns an empty string
- `Type.String()` provides the full type representation for all types

### Solution
Modified `JSONTypeError.Error()` method to:
1. Check if `Type.Name()` returns an empty string
2. Fall back to `Type.String()` for unnamed types
3. Maintain existing behavior for defined types

### Backward Compatibility
- ✅ No breaking changes
- ✅ Existing defined type behavior unchanged
- ✅ Only improves error message clarity

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211106166549889